### PR TITLE
Modify eslint Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+**UPDATE, 9/4/20 | All versions past 1.1.1 will now be documented in the repo's [release page](https://github.com/britannica/cra-template/releases)**
+
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ### [1.1.1](https://github.com/britannica/cra-template/compare/v1.1.0...v1.1.1) (2020-05-11)

--- a/template.json
+++ b/template.json
@@ -15,7 +15,7 @@
       "@testing-library/jest-dom": "^5.11.4",
       "@testing-library/react": "^11.0.2",
       "babel-eslint": "10.1.0",
-      "eslint": "^7.8.1",
+      "eslint": "6.6.0",
       "eslint-config-prettier": "^6.11.0",
       "eslint-plugin-import": "^2.22.0",
       "eslint-plugin-jsx-a11y": "^6.3.1",


### PR DESCRIPTION
In order to avoid a conflict with the version of `eslint` needed by `react-scripts` we have changed the version of `eslint` in `template.json` to match the version needed by `react-scripts`.